### PR TITLE
Add content protection configuration for copied messages

### DIFF
--- a/src/main/java/org/telegram/forcesub/handler/CommandHandlerProcessor.java
+++ b/src/main/java/org/telegram/forcesub/handler/CommandHandlerProcessor.java
@@ -2,6 +2,7 @@ package org.telegram.forcesub.handler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.api.methods.CopyMessage;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
@@ -83,11 +84,12 @@ public interface CommandHandlerProcessor {
      * @param bot The telegram client instance
      */
     
-    default void copyMessage(String fromChatId, String messageId, Long toChatId, TelegramClient bot) {
+    default void copyMessage(String fromChatId, String messageId, Long toChatId,Boolean protect, TelegramClient bot) {
         CopyMessage copy = CopyMessage.builder()
                 .fromChatId(fromChatId)
                 .messageId(Integer.parseInt(messageId))
                 .chatId(toChatId)
+                .protectContent(protect)
                 .build();
         try {
             bot.execute(copy);

--- a/src/main/java/org/telegram/forcesub/handler/StartCommand.java
+++ b/src/main/java/org/telegram/forcesub/handler/StartCommand.java
@@ -30,19 +30,22 @@ public class StartCommand implements CommandHandlerProcessor {
     private final MessageService messageService;
     private final MappingText mappingText;
     private final long DELAY_EACH_COPY_MESSAGE = 1000;
+    private final boolean IS_PROTECT_CONTENT;
 
     public StartCommand(MessageService messageService,
                         SubscriptionService subscriptionService,
                         GetChannelLinkService getChannelLinkService,
                         JoinButton joinButton,
                         @Value("${bot.username}") String botUsername,
-                        MappingText mappingText) {
+                        MappingText mappingText,
+                        @Value("${data.message}") String protectContent) {
         this.messageService = messageService;
         this.subscriptionService = subscriptionService;
         this.getChannelLinkService = getChannelLinkService;
         this.joinButton = joinButton;
         this.botUsername = botUsername;
         this.mappingText = mappingText;
+        this.IS_PROTECT_CONTENT = Boolean.getBoolean(protectContent);
     }
 
     @Override
@@ -99,7 +102,7 @@ public class StartCommand implements CommandHandlerProcessor {
             messages.forEach(message -> {
                 log.info("Processing message: {}", message);
                 try {
-                    copyMessage(message.getChatId(), message.getMessageId(), chatId, telegramClient);
+                    copyMessage(message.getChatId(), message.getMessageId(), chatId, IS_PROTECT_CONTENT, telegramClient);
                     Thread.sleep(DELAY_EACH_COPY_MESSAGE);
                 } catch (InterruptedException e) {
                     log.warn("Thread interrupted while sleeping: {}", e.getMessage());

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -24,6 +24,7 @@ channel.id=
 bot.id=
 admin.id=
 data.message=
+protect.content=true
 
 start.message.not.join=
 start.message.after.join=


### PR DESCRIPTION
Introduced a new property `protect.content` in application settings to enable or disable content protection when copying messages. Updated relevant classes to utilize this configuration and pass the `protectContent` parameter accordingly. This ensures added flexibility in message handling based on user preferences.